### PR TITLE
feat(address): extract region (state) field in VCF strategy

### DIFF
--- a/src/__tests__/core/VcfAddressVerification.test.ts
+++ b/src/__tests__/core/VcfAddressVerification.test.ts
@@ -12,6 +12,7 @@ describe('VCF Address Verification', () => {
         {
           streetAddress: 'Salaspils iela 18',
           city: 'Riga',
+          region: 'Vidzeme',
           country: 'Latvia',
           postalCode: 'LV-1000',
           formattedValue: 'Salaspils iela 18\nRiga\nLatvia',
@@ -34,6 +35,7 @@ describe('VCF Address Verification', () => {
 
     expect(result['ADR.STREET']).toBe('Salaspils iela 18');
     expect(result['ADR.CITY']).toBe('Riga');
+    expect(result['ADR.REGION']).toBe('Vidzeme');
     expect(result['ADR.COUNTRY']).toBe('Latvia');
     expect(result['ADR.POSTALCODE']).not.toBeUndefined(); // AddressAdapter uses POSTALCODE suffix
   });

--- a/src/__tests__/core/adapters/Adapters.test.ts
+++ b/src/__tests__/core/adapters/Adapters.test.ts
@@ -56,6 +56,7 @@ describe('Adapters', () => {
           {
             formattedValue: '123 Main St',
             city: '',
+            region: '',
             country: '',
             countryCode: '',
             extendedAddress: '',
@@ -77,6 +78,7 @@ describe('Adapters', () => {
           {
             streetAddress: '123 Main St',
             city: 'Anytown',
+            region: 'Anystate',
             country: 'USA',
             postalCode: '12345',
             formattedType: 'Home',
@@ -93,6 +95,7 @@ describe('Adapters', () => {
       expect(result).toEqual([
         { value: '123 Main St', suffix: 'STREET', index: 0 },
         { value: 'Anytown', suffix: 'CITY', index: 0 },
+        { value: 'Anystate', suffix: 'REGION', index: 0 },
         { value: 'USA', suffix: 'COUNTRY', index: 0 },
         { value: '12345', suffix: 'POSTALCODE', index: 0 },
         { value: 'Home', suffix: 'TYPE', index: 0 },

--- a/src/__tests__/core/adapters/AddressAdapter.test.ts
+++ b/src/__tests__/core/adapters/AddressAdapter.test.ts
@@ -15,6 +15,7 @@ describe('AddressAdapter', () => {
     formattedType: '',
     formattedValue: '',
     postalCode: '',
+    region: '',
     streetAddress: '',
     type: '',
     ...overrides,
@@ -26,11 +27,12 @@ describe('AddressAdapter', () => {
       createAddress({
         streetAddress: '123 Main St',
         city: 'Springfield',
+        region: 'IL',
         country: 'USA',
         postalCode: '12345',
         extendedAddress: 'Apt 4B',
         formattedType: 'Home',
-        formattedValue: '123 Main St\nSpringfield, USA 12345',
+        formattedValue: '123 Main St\nSpringfield, IL USA 12345',
       }),
       createAddress({
         streetAddress: '456 Office Rd',
@@ -48,7 +50,7 @@ describe('AddressAdapter', () => {
       const results = adapter.extract(mockContact);
       expect(results).toHaveLength(2);
       expect(results[0]).toEqual({
-        value: '123 Main St\nSpringfield, USA 12345',
+        value: '123 Main St\nSpringfield, IL USA 12345',
       });
       expect(results[1]).toEqual({
         value: '456 Office Rd\nWorktown, UK AB1 2CD',
@@ -95,7 +97,7 @@ describe('AddressAdapter', () => {
       expect(results).toEqual([
         {
           value: [
-            '123 Main St\nSpringfield, USA 12345',
+            '123 Main St\nSpringfield, IL USA 12345',
             '456 Office Rd\nWorktown, UK AB1 2CD',
           ],
         },
@@ -110,7 +112,7 @@ describe('AddressAdapter', () => {
       const results = adapter.extract(singleContact, contextWithArray);
       expect(results).toEqual([
         {
-          value: '123 Main St\nSpringfield, USA 12345',
+          value: '123 Main St\nSpringfield, IL USA 12345',
         },
       ]);
     });
@@ -131,13 +133,14 @@ describe('AddressAdapter', () => {
         expect.arrayContaining([
           { value: '123 Main St', suffix: 'STREET', index: 0 },
           { value: 'Springfield', suffix: 'CITY', index: 0 },
+          { value: 'IL', suffix: 'REGION', index: 0 },
           { value: 'USA', suffix: 'COUNTRY', index: 0 },
           { value: '12345', suffix: 'POSTALCODE', index: 0 },
           { value: 'Apt 4B', suffix: 'EXTENDED', index: 0 },
           { value: 'Home', suffix: 'TYPE', index: 0 },
         ])
       );
-      expect(results).toHaveLength(6);
+      expect(results).toHaveLength(7);
     });
 
     it('assigns correct index for multiple addresses', () => {

--- a/src/core/adapters/AddressAdapter.ts
+++ b/src/core/adapters/AddressAdapter.ts
@@ -50,6 +50,7 @@ export class AddressAdapter implements FieldAdapter {
         const fields = [
           { value: addr.streetAddress, suffix: 'STREET' },
           { value: addr.city, suffix: 'CITY' },
+          { value: addr.region, suffix: 'REGION' },
           { value: addr.country, suffix: 'COUNTRY' },
           { value: addr.postalCode, suffix: 'POSTALCODE' },
           { value: addr.extendedAddress, suffix: 'EXTENDED' },

--- a/src/types/Contact.ts
+++ b/src/types/Contact.ts
@@ -47,6 +47,7 @@ export interface GoogleContact {
     formattedType: string;
     formattedValue: string;
     postalCode: string;
+    region: string;
     streetAddress: string;
     type: string;
   }[];


### PR DESCRIPTION
feat(address): extract region (state) field in VCF strategy

Added the extraction of the Google Contact `region` field to the AddressAdapter. 
This surfaces the state/region part of the address as `REGION` suffix (e.g. `ADR.REGION`) 
which was previously missing when using the VCF naming strategy.

Closes #42