### PR TITLE
feat: sync website URLs from Google Contacts

### DIFF
--- a/src/__tests__/core/adapters/UrlAdapter.test.ts
+++ b/src/__tests__/core/adapters/UrlAdapter.test.ts
@@ -1,0 +1,108 @@
+import { UrlAdapter } from '../../../core/adapters/UrlAdapter';
+import { GoogleContact } from '../../../types/Contact';
+
+describe('UrlAdapter', () => {
+  const adapter = new UrlAdapter();
+
+  describe('extract', () => {
+    it('should extract URLs as array', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [
+          { value: 'https://twitter.com/user' },
+          { value: 'https://github.com/user' },
+        ],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([
+        { value: ['https://twitter.com/user', 'https://github.com/user'] },
+      ]);
+    });
+
+    it('should return empty array if no URLs', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array if URLs is empty array', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([]);
+    });
+
+    it('should filter out URLs with empty values', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [
+          { value: 'https://valid.com' },
+          { value: '' },
+          { value: 'https://another.com' },
+        ],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([
+        { value: ['https://valid.com', 'https://another.com'] },
+      ]);
+    });
+
+    it('should return empty array if all URLs have empty values', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [{ value: '' }, { value: '' }],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([]);
+    });
+
+    it('should include type if present but type is ignored in Option A', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [
+          { value: 'https://twitter.com/user', type: 'twitter' },
+          { value: 'https://github.com/user', type: 'github' },
+        ],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([
+        { value: ['https://twitter.com/user', 'https://github.com/user'] },
+      ]);
+    });
+  });
+
+  describe('with website context', () => {
+    it('should return empty array when website context is false', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [{ value: 'https://example.com' }],
+      };
+      const context = { website: false };
+      const result = adapter.extract(contact, context);
+      expect(result).toEqual([]);
+    });
+
+    it('should extract URLs when website context is true', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [{ value: 'https://example.com' }],
+      };
+      const context = { website: true };
+      const result = adapter.extract(contact, context);
+      expect(result).toEqual([{ value: ['https://example.com'] }]);
+    });
+
+    it('should extract URLs when website context is undefined (default)', () => {
+      const contact: GoogleContact = {
+        resourceName: 'people/123',
+        urls: [{ value: 'https://example.com' }],
+      };
+      const result = adapter.extract(contact);
+      expect(result).toEqual([{ value: ['https://example.com'] }]);
+    });
+  });
+});

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -15,4 +15,5 @@ export const DEFAULT_TEST_CONFIG: ContactNoteConfig = {
   lastFirst: false,
   skipNamelessContacts: false,
   useContactTypes: false,
+  website: true,
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,7 @@ export const URL_OAUTH_TOKEN = 'https://oauth2.googleapis.com/token';
 /** Google People API endpoints */
 const URL_PEOPLE_BASE = 'https://people.googleapis.com/v1';
 export const URL_PEOPLE_CONNECTIONS = `${URL_PEOPLE_BASE}/people/me/connections`;
-export const PERSONAL_FIELDS = `names,emailAddresses,phoneNumbers,birthdays,memberships,metadata,addresses,biographies,organizations,relations`;
+export const PERSONAL_FIELDS = `names,emailAddresses,phoneNumbers,birthdays,memberships,metadata,addresses,biographies,organizations,relations,urls`;
 export const OTHER_CONTACTS_FIELDS = `names,emailAddresses,phoneNumbers`;
 export const URL_CONTACT_GROUPS = `${URL_PEOPLE_BASE}/contactGroups?pageSize=1000`;
 
@@ -44,4 +44,5 @@ export const DEFAULT_SETTINGS: ContactSyncSettings = {
   lastFirst: false,
   skipNamelessContacts: false,
   useContactTypes: false,
+  website: true,
 };

--- a/src/core/Formatter.ts
+++ b/src/core/Formatter.ts
@@ -14,6 +14,7 @@ import { DepartmentAdapter } from './adapters/DepartmentAdapter';
 import { BirthdayAdapter } from './adapters/BirthdayAdapter';
 import { LabelAdapter } from './adapters/LabelAdapter';
 import { RelationsAdapter } from './adapters/RelationsAdapter';
+import { UrlAdapter } from './adapters/UrlAdapter';
 
 /**
  * Formatter class responsible for coordinating field extraction and key generation.
@@ -22,7 +23,7 @@ export class Formatter {
   constructor(
     private adapters: Record<string, FieldAdapter>,
     private strategy: KeyNamingStrategy
-  ) { }
+  ) {}
 
   /**
    * Generates a frontmatter object from a Google Contact.
@@ -107,6 +108,7 @@ export function createDefaultFormatter(
     department: new DepartmentAdapter(),
     labels: new LabelAdapter(),
     relations: new RelationsAdapter(),
+    url: new UrlAdapter(),
   };
 
   if (strategyType === NamingStrategy.VCF) {

--- a/src/core/adapters/AddressAdapter.ts
+++ b/src/core/adapters/AddressAdapter.ts
@@ -16,7 +16,9 @@ export class AddressAdapter implements FieldAdapter {
 
     const typeCounts: Record<string, number> = {};
     const processType = (typeStr?: string) => {
-      let normalizedType = (typeStr ?? 'other').toLowerCase().replace(/[^a-z0-9]/g, '');
+      let normalizedType = (typeStr ?? 'other')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
       if (!normalizedType) {
         normalizedType = 'other';
       }
@@ -102,7 +104,9 @@ export class AddressAdapter implements FieldAdapter {
     const results: ExtractionResult[] = [];
 
     for (const item of validAddresses) {
-      let normalizedType = (item.type ?? 'other').toLowerCase().replace(/[^a-z0-9]/g, '');
+      let normalizedType = (item.type ?? 'other')
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, '');
       if (!normalizedType) {
         normalizedType = 'other';
       }

--- a/src/core/adapters/UrlAdapter.ts
+++ b/src/core/adapters/UrlAdapter.ts
@@ -1,0 +1,20 @@
+import { FieldAdapter, ExtractionResult } from '../interfaces';
+import { GoogleContact } from '../../types/Contact';
+
+export class UrlAdapter implements FieldAdapter {
+  extract(
+    contact: GoogleContact,
+    context?: Record<string, unknown>
+  ): ExtractionResult[] {
+    if (context?.website === false) {
+      return [];
+    }
+
+    const validUrls = (contact.urls ?? []).filter((item) => item.value);
+    if (validUrls.length === 0) {
+      return [];
+    }
+
+    return [{ value: validUrls.map((item) => item.value) }];
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -216,6 +216,7 @@ export default class GoogleContactsSyncPlugin extends Plugin {
       lastFirst: this.settings.lastFirst,
       skipNamelessContacts: this.settings.skipNamelessContacts,
       useContactTypes: this.settings.useContactTypes,
+      website: this.settings.website,
     };
   }
 

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -135,6 +135,22 @@ export class ContactSyncSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName(t('Sync website URLs'))
+      .setDesc(
+        t(
+          'If enabled, website URLs from contacts will be synced to the website frontmatter property'
+        )
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.website)
+          .onChange(async (value) => {
+            this.plugin.settings.website = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
       .setName(t('Naming strategy'))
       .setDesc(t('Strategy to generate frontmatter keys from contact data'))
       .addDropdown((dropdown) =>

--- a/src/types/Contact.ts
+++ b/src/types/Contact.ts
@@ -63,6 +63,11 @@ export interface GoogleContact {
     type: string;
     metadata: string;
   }[];
+
+  urls?: {
+    value: string;
+    type?: string;
+  }[];
 }
 
 /**

--- a/src/types/ContactNoteConfig.ts
+++ b/src/types/ContactNoteConfig.ts
@@ -14,4 +14,5 @@ export interface ContactNoteConfig {
   lastFirst: boolean;
   skipNamelessContacts: boolean;
   useContactTypes: boolean;
+  website: boolean;
 }

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -64,6 +64,9 @@ export interface ContactSyncSettings {
 
   /** Whether to use contact types for emails, phones and addresses instead of index */
   useContactTypes: boolean;
+
+  /** Whether to sync website URLs from contacts */
+  website: boolean;
 }
 
 export enum NamingStrategy {


### PR DESCRIPTION
## Summary
- Add `urls` field to Google Contacts sync (Google People API provides this data)
- New `UrlAdapter` extracts URLs as array for frontmatter output: `website: [url1, url2, ...]`
- Add `website` toggle in settings (enabled by default)
## Changes
- `src/types/Contact.ts` - Added `urls` interface
- `src/types/Settings.ts` - Added `website: boolean`
- `src/config/index.ts` - Added `urls` to PERSONAL_FIELDS
- `src/core/adapters/UrlAdapter.ts` - New adapter
- `src/core/Formatter.ts` - Register UrlAdapter
- `src/plugin/settings.ts` - Toggle UI
- Tests added
## Testing
All 128 tests pass, lint clean.