### PR TITLE
feat: exclude label filter + fix user-created label resolution (#34)

### DIFF
--- a/src/__tests__/core/ContactNoteWriter.test.ts
+++ b/src/__tests__/core/ContactNoteWriter.test.ts
@@ -67,9 +67,10 @@ class TestContactNoteWriter extends ContactNoteWriter {
   public hasSyncLabel(
     contact: GoogleContact,
     syncLabel: string,
+    excludeLabel: string,
     labelMap: Record<string, string>
   ): boolean {
-    return super.hasSyncLabel(contact, syncLabel, labelMap);
+    return super.hasSyncLabel(contact, syncLabel, excludeLabel, labelMap);
   }
 }
 
@@ -391,6 +392,7 @@ describe('ContactNoteWriter', () => {
       const result = contactNoteWriter.hasSyncLabel(
         mockContact,
         'family',
+        '',
         mockLabelMap
       );
 
@@ -413,6 +415,7 @@ describe('ContactNoteWriter', () => {
       const result = contactNoteWriter.hasSyncLabel(
         mockContact,
         'family',
+        '',
         mockLabelMap
       );
 
@@ -429,10 +432,85 @@ describe('ContactNoteWriter', () => {
       const result = contactNoteWriter.hasSyncLabel(
         mockContact,
         'family',
+        '',
         mockLabelMap
       );
 
       expect(result).toBe(false);
+    });
+
+    it('should return false if contact has the exclude label', () => {
+      const mockContact: GoogleContact = {
+        resourceName: 'people/123',
+        memberships: [
+          {
+            contactGroupMembership: {
+              contactGroupId: 'group2',
+            },
+          },
+        ],
+      };
+      const mockLabelMap = { excluded: 'group2' };
+
+      const result = contactNoteWriter.hasSyncLabel(
+        mockContact,
+        '',
+        'excluded',
+        mockLabelMap
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if contact has both sync and exclude labels', () => {
+      const mockContact: GoogleContact = {
+        resourceName: 'people/123',
+        memberships: [
+          {
+            contactGroupMembership: {
+              contactGroupId: 'group1',
+            },
+          },
+          {
+            contactGroupMembership: {
+              contactGroupId: 'group2',
+            },
+          },
+        ],
+      };
+      const mockLabelMap = { family: 'group1', excluded: 'group2' };
+
+      const result = contactNoteWriter.hasSyncLabel(
+        mockContact,
+        'family',
+        'excluded',
+        mockLabelMap
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('should not exclude contact if excludeLabel is unknown', () => {
+      const mockContact: GoogleContact = {
+        resourceName: 'people/123',
+        memberships: [
+          {
+            contactGroupMembership: {
+              contactGroupId: 'group1',
+            },
+          },
+        ],
+      };
+      const mockLabelMap = { family: 'group1' };
+
+      const result = contactNoteWriter.hasSyncLabel(
+        mockContact,
+        'family',
+        'nonexistent',
+        mockLabelMap
+      );
+
+      expect(result).toBe(true);
     });
   });
 

--- a/src/__tests__/core/GoogleContactsService.test.ts
+++ b/src/__tests__/core/GoogleContactsService.test.ts
@@ -4,6 +4,7 @@ import {
   URL_PEOPLE_CONNECTIONS,
   PERSONAL_FIELDS,
   URL_CONTACT_GROUPS,
+  URL_CONTACT_GROUPS_BATCH,
 } from '../../config';
 import type { GoogleContact, GoogleContactGroup } from '../../types/Contact';
 
@@ -138,12 +139,8 @@ describe('GoogleContactsService', () => {
     });
 
     it('should return an empty object when no contactGroups are provided', async () => {
-      const mockData = {
-        contactGroups: [],
-      };
-
       (requestUrl as jest.Mock).mockResolvedValue({
-        json: Promise.resolve(mockData),
+        json: Promise.resolve({ contactGroups: [] }),
       });
 
       const result = await googleContactsService.fetchGoogleGroups('someToken');
@@ -152,85 +149,106 @@ describe('GoogleContactsService', () => {
     });
 
     it('should map group names to their resource names', async () => {
-      const mockData = {
-        contactGroups: [
-          {
-            name: 'Family',
-            resourceName: 'contactGroups/group1',
-          },
-          {
-            name: 'Friends',
-            resourceName: 'contactGroups/group2',
-          },
-        ],
-      };
-
       (requestUrl as jest.Mock).mockResolvedValue({
-        json: Promise.resolve(mockData),
+        json: Promise.resolve({
+          contactGroups: [
+            { name: 'Family', resourceName: 'contactGroups/group1' },
+            { name: 'Friends', resourceName: 'contactGroups/group2' },
+          ],
+        }),
       });
 
       const result = await googleContactsService.fetchGoogleGroups('someToken');
 
-      const expectedLabelMap = {
-        family: 'group1',
-        friends: 'group2',
-      };
-
-      expect(result).toEqual(expectedLabelMap);
+      expect(result).toEqual({ family: 'group1', friends: 'group2' });
     });
 
     it('should remove "contactGroups/" from resourceName', async () => {
-      const mockData = {
-        contactGroups: [
-          {
-            name: 'Work',
-            resourceName: 'contactGroups/workGroup',
-          },
-        ],
-      };
-
       (requestUrl as jest.Mock).mockResolvedValue({
-        json: Promise.resolve(mockData),
+        json: Promise.resolve({
+          contactGroups: [{ name: 'Work', resourceName: 'contactGroups/workGroup' }],
+        }),
       });
 
       const result = await googleContactsService.fetchGoogleGroups('someToken');
 
-      const expectedLabelMap = {
-        work: 'workGroup',
-      };
+      expect(result).toEqual({ work: 'workGroup' });
+    });
 
-      expect(result).toEqual(expectedLabelMap);
+    it('should lowercase group names as keys', async () => {
+      (requestUrl as jest.Mock).mockResolvedValue({
+        json: Promise.resolve({
+          contactGroups: [{ name: 'MyLabel', resourceName: 'contactGroups/abc' }],
+        }),
+      });
+
+      const result = await googleContactsService.fetchGoogleGroups(mockToken);
+      expect(result).toEqual({ mylabel: 'abc' });
     });
 
     it('should not add group to labelMap if name or resourceName is missing', async () => {
-      const mockData = {
-        contactGroups: [
-          {
-            name: 'Team',
-            resourceName: 'contactGroups/teamGroup',
-          },
-          {
-            name: '', // invalid name
-            resourceName: 'contactGroups/invalidGroup',
-          },
-          {
-            name: 'Other', // valid name
-            resourceName: '', // invalid resourceName
-          },
-        ],
-      };
-
       (requestUrl as jest.Mock).mockResolvedValue({
-        json: Promise.resolve(mockData),
+        json: Promise.resolve({
+          contactGroups: [
+            { name: 'Team', resourceName: 'contactGroups/teamGroup' },
+            { name: '', resourceName: 'contactGroups/invalidGroup' },
+            { name: 'Other', resourceName: '' },
+          ],
+        }),
       });
 
       const result = await googleContactsService.fetchGoogleGroups('someToken');
 
-      const expectedLabelMap = {
-        team: 'teamGroup',
-      };
+      expect(result).toEqual({ team: 'teamGroup' });
+    });
+  });
 
-      expect(result).toEqual(expectedLabelMap);
+  describe('batchGetGroups', () => {
+    it('should return empty object for empty input', async () => {
+      const result = await googleContactsService.batchGetGroups(mockToken, []);
+      expect(result).toEqual({});
+      expect(requestUrl).not.toHaveBeenCalled();
+    });
+
+    it('should fetch and map groups by ID', async () => {
+      (requestUrl as jest.Mock).mockResolvedValue({
+        json: Promise.resolve({
+          responses: [
+            { contactGroup: { name: 'Friends', resourceName: 'contactGroups/abc123' } },
+            { contactGroup: { name: 'Family', resourceName: 'contactGroups/def456' } },
+          ],
+        }),
+      });
+
+      const result = await googleContactsService.batchGetGroups(mockToken, ['abc123', 'def456']);
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining(URL_CONTACT_GROUPS_BATCH),
+          method: 'GET',
+        })
+      );
+      expect(result).toEqual({ friends: 'abc123', family: 'def456' });
+    });
+
+    it('should skip responses without contactGroup', async () => {
+      (requestUrl as jest.Mock).mockResolvedValue({
+        json: Promise.resolve({
+          responses: [
+            { requestedResourceName: 'contactGroups/deleted', contactGroup: undefined },
+            { contactGroup: { name: 'Work', resourceName: 'contactGroups/work1' } },
+          ],
+        }),
+      });
+
+      const result = await googleContactsService.batchGetGroups(mockToken, ['deleted', 'work1']);
+      expect(result).toEqual({ work: 'work1' });
+    });
+
+    it('should return empty object on API error', async () => {
+      (requestUrl as jest.Mock).mockRejectedValue(new Error('Network error'));
+      const result = await googleContactsService.batchGetGroups(mockToken, ['abc123']);
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -16,4 +16,5 @@ export const DEFAULT_TEST_CONFIG: ContactNoteConfig = {
   skipNamelessContacts: false,
   useContactTypes: false,
   website: true,
+  excludeLabel: '',
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,7 @@ export const URL_PEOPLE_CONNECTIONS = `${URL_PEOPLE_BASE}/people/me/connections`
 export const PERSONAL_FIELDS = `names,emailAddresses,phoneNumbers,birthdays,memberships,metadata,addresses,biographies,organizations,relations,urls,photos`;
 export const OTHER_CONTACTS_FIELDS = `names,emailAddresses,phoneNumbers`;
 export const URL_CONTACT_GROUPS = `${URL_PEOPLE_BASE}/contactGroups?pageSize=1000`;
+export const URL_CONTACT_GROUPS_BATCH = `${URL_PEOPLE_BASE}/contactGroups:batchGet`;
 
 export const URL_PEOPLE_OTHER_CONTACTS = `${URL_PEOPLE_BASE}/otherContacts`;
 
@@ -45,4 +46,5 @@ export const DEFAULT_SETTINGS: ContactSyncSettings = {
   skipNamelessContacts: false,
   useContactTypes: false,
   website: true,
+  excludeLabel: '',
 };

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -100,6 +100,10 @@ export const ru = {
     'Использовать типы для e-mail, телефонов и адресов',
   'If enabled, emails, phones and addresses will be formatted with their specific types (e.g. email_work, phone_mobile, address_home) instead of generic indexes. This is ignored in the Array naming strategy.':
     'Если включено, электронные адреса, телефоны и адреса будут отформатированы с учетом их типов (например, email_work, phone_mobile, address_home) вместо индексов. Игнорируется в стратегии "Массив".',
+  'Label to exclude': 'Лейбл для исключения',
+  'If not empty, contacts with this label will be excluded from sync':
+    'Если указан, контакты с этим лейблом будут исключены из синхронизации',
+  'e.g. excluded': 'например, excluded',
 };
 
 /**
@@ -204,6 +208,10 @@ export const lv = {
     'Izmantot e-pasta, tālruņa un adrešu tipus',
   'If enabled, emails, phones and addresses will be formatted with their specific types (e.g. email_work, phone_mobile, address_home) instead of generic indexes. This is ignored in the Array naming strategy.':
     'Ja iespējots, e-pasti, tālruņi un adreses tiks formatēti ar to specifiskajiem tipiem (piem., email_work, phone_mobile, address_home), nevis vispārīgiem rādītājiem. Tas tiek ignorēts Array nosaukšanas stratēģijā.',
+  'Label to exclude': 'Etiķete izslēgšanai',
+  'If not empty, contacts with this label will be excluded from sync':
+    'Ja nav tukšs, kontakti ar šo etiķeti tiks izslēgti no sinhronizācijas',
+  'e.g. excluded': 'piem., excluded',
 };
 
 /**
@@ -306,4 +314,8 @@ export const en = {
     'Use contact types for emails, phones and addresses',
   'If enabled, emails, phones and addresses will be formatted with their specific types (e.g. email_work, phone_mobile, address_home) instead of generic indexes. This is ignored in the Array naming strategy.':
     'If enabled, emails, phones and addresses will be formatted with their specific types (e.g. email_work, phone_mobile, address_home) instead of generic indexes. This is ignored in the Array naming strategy.',
+  'Label to exclude': 'Label to exclude',
+  'If not empty, contacts with this label will be excluded from sync':
+    'If not empty, contacts with this label will be excluded from sync',
+  'e.g. excluded': 'e.g. excluded',
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,13 +143,13 @@ export default class GoogleContactsSyncPlugin extends Plugin {
       return;
     }
 
-    const labelMap = await this.getLabelMap(token);
-    if (!labelMap) {
+    const contacts = await this.getContacts(token);
+    if (!contacts) {
       return;
     }
 
-    const contacts = await this.getContacts(token);
-    if (!contacts) {
+    const labelMap = await this.getLabelMap(token, contacts);
+    if (!labelMap) {
       return;
     }
 
@@ -169,11 +169,42 @@ export default class GoogleContactsSyncPlugin extends Plugin {
     return token;
   }
 
+  private collectUnknownGroupIds(
+    contacts: GoogleContact[],
+    knownIds: Set<string>
+  ): string[] {
+    const unknownIds = new Set<string>();
+    for (const contact of contacts) {
+      for (const m of contact.memberships ?? []) {
+        const id = m.contactGroupMembership?.contactGroupId;
+        if (id && !knownIds.has(id)) {
+          unknownIds.add(id);
+        }
+      }
+    }
+    return [...unknownIds];
+  }
+
   private async getLabelMap(
-    token: string
+    token: string,
+    contacts: GoogleContact[]
   ): Promise<Record<string, string> | null> {
     try {
-      return (await this.googleService?.fetchGoogleGroups(token)) ?? {};
+      const labelMap =
+        (await this.googleService?.fetchGoogleGroups(token)) ?? {};
+
+      const unknownIds = this.collectUnknownGroupIds(
+        contacts,
+        new Set(Object.values(labelMap))
+      );
+
+      if (unknownIds.length > 0) {
+        const extra =
+          (await this.googleService?.batchGetGroups(token, unknownIds)) ?? {};
+        Object.assign(labelMap, extra);
+      }
+
+      return labelMap;
     } catch (error) {
       console.error(
         'Failed to fetch Google groups',
@@ -217,6 +248,7 @@ export default class GoogleContactsSyncPlugin extends Plugin {
       skipNamelessContacts: this.settings.skipNamelessContacts,
       useContactTypes: this.settings.useContactTypes,
       website: this.settings.website,
+      excludeLabel: this.settings.excludeLabel,
     };
   }
 

--- a/src/plugin/settings.ts
+++ b/src/plugin/settings.ts
@@ -228,6 +228,21 @@ export class ContactSyncSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName(t('Label to exclude'))
+      .setDesc(
+        t('If not empty, contacts with this label will be excluded from sync')
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder(t('e.g. excluded'))
+          .setValue(this.plugin.settings.excludeLabel)
+          .onChange(async (value) => {
+            this.plugin.settings.excludeLabel = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    new Setting(containerEl)
       .setName(t('Auto sync period'))
       .setDesc(t('Period in minutes. If 0, then never. 1 day = 1440'))
       .addText((text) =>

--- a/src/services/ContactNoteWriter.ts
+++ b/src/services/ContactNoteWriter.ts
@@ -104,7 +104,7 @@ export class ContactNoteWriter {
     labelMap: Record<string, string>,
     filesIdMapping: Record<string, TFile>
   ): Promise<void> {
-    if (!this.hasSyncLabel(contact, context.syncLabel, labelMap)) {
+    if (!this.hasSyncLabel(contact, context.syncLabel, context.excludeLabel, labelMap)) {
       return;
     }
 
@@ -326,14 +326,26 @@ export class ContactNoteWriter {
   protected hasSyncLabel(
     contact: GoogleContact,
     syncLabel: string,
+    excludeLabel: string,
     labelMap: Record<string, string>
   ): boolean {
+    const memberships = contact.memberships ?? [];
+
+    if (excludeLabel) {
+      const excludeGroupId = labelMap[excludeLabel];
+      if (excludeGroupId && memberships.some(
+        (m) => m.contactGroupMembership?.contactGroupId === excludeGroupId
+      )) {
+        return false;
+      }
+    }
+
     if (!syncLabel) {
       return true;
     }
 
     const targetGroupId = labelMap[syncLabel];
-    return (contact.memberships ?? []).some(
+    return memberships.some(
       (m) => m.contactGroupMembership?.contactGroupId === targetGroupId
     );
   }

--- a/src/services/GoogleContactsService.ts
+++ b/src/services/GoogleContactsService.ts
@@ -1,6 +1,7 @@
 import { requestUrl } from 'obsidian';
 import {
   URL_CONTACT_GROUPS,
+  URL_CONTACT_GROUPS_BATCH,
   URL_PEOPLE_CONNECTIONS,
   PERSONAL_FIELDS,
   URL_PEOPLE_OTHER_CONTACTS,
@@ -21,6 +22,13 @@ interface OtherContactsResponse {
 
 interface ContactGroupsResponse {
   contactGroups?: GoogleContactGroup[];
+}
+
+interface BatchGetContactGroupsResponse {
+  responses?: {
+    requestedResourceName?: string;
+    contactGroup?: GoogleContactGroup;
+  }[];
 }
 
 /**
@@ -160,5 +168,53 @@ export class GoogleContactsService {
       }
     });
     return labelMap;
+  }
+
+  /**
+   * Fetches contact groups by their IDs and returns a mapping of lowercase group name → group ID.
+   * Used to resolve group IDs that are present in contact memberships but missing from the
+   * contactGroups.list response (e.g. legacy groups or groups created via the old Contacts API).
+   * @param token OAuth access token.
+   * @param groupIds Array of group IDs (without the "contactGroups/" prefix).
+   * @returns Record mapping lowercase group names to their resource IDs.
+   */
+  async batchGetGroups(
+    token: string,
+    groupIds: string[]
+  ): Promise<Record<string, string>> {
+    if (groupIds.length === 0) {
+      return {};
+    }
+
+    const params = new URLSearchParams();
+    groupIds.forEach((id) => {
+      params.append('resourceNames', `contactGroups/${id}`);
+    });
+
+    try {
+      const response = await requestUrl({
+        url: `${URL_CONTACT_GROUPS_BATCH}?${params.toString()}`,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      const data =
+        (await response.json) as BatchGetContactGroupsResponse;
+      const result: Record<string, string> = {};
+
+      data.responses?.forEach((r) => {
+        const group = r.contactGroup;
+        if (group?.name && group.resourceName) {
+          result[group.name.toLowerCase()] = group.resourceName.replace(
+            'contactGroups/',
+            ''
+          );
+        }
+      });
+
+      return result;
+    } catch {
+      return {};
+    }
   }
 }

--- a/src/types/ContactNoteConfig.ts
+++ b/src/types/ContactNoteConfig.ts
@@ -15,4 +15,5 @@ export interface ContactNoteConfig {
   skipNamelessContacts: boolean;
   useContactTypes: boolean;
   website: boolean;
+  excludeLabel: string;
 }

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -67,6 +67,9 @@ export interface ContactSyncSettings {
 
   /** Whether to sync website URLs from contacts */
   website: boolean;
+
+  /** Name of the contact group to exclude from sync */
+  excludeLabel: string;
 }
 
 export enum NamingStrategy {


### PR DESCRIPTION
Adds an "exclude label" setting so contacts tagged with a specific label are skipped during sync regardless of the sync label filter. Exclusion takes precedence over inclusion.

Also fixes a bug where user-created labels were missing from contact frontmatter and label filters had no effect: Google's contactGroups.list omits groups created via the legacy Contacts API. After fetching contacts, unknown group IDs found in memberships are now resolved via a contactGroups:batchGet call, ensuring all labels are mapped correctly.

(#34)